### PR TITLE
Fixed minor issue: import 'Linking'

### DIFF
--- a/components/DrawerItem.js
+++ b/components/DrawerItem.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet, TouchableOpacity } from "react-native";
+import { StyleSheet, TouchableOpacity, Linking } from "react-native";
 import { Block, Text, theme } from "galio-framework";
 
 import Icon from "./Icon";


### PR DESCRIPTION
Clicking on 'Getting Started' in Navigation would produce an error. Importing 'Linking' from react-native fixes this.